### PR TITLE
fixes typo that was breaking functionality

### DIFF
--- a/src/components/ratingsAndReviews/RatingScale.jsx
+++ b/src/components/ratingsAndReviews/RatingScale.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react'
-import {VscTriangleDown} from 'react-icons/Vsc'
+import {VscTriangleDown} from 'react-icons/vsc'
 
 const RatingScale = ({characteristic}) => {
   const des = {Comfort: ['Uncomfortable', 'Perfect'], Fit: ['Too tight', 'Too long'], Length: ['Too short', 'Too long'], Quality: ['Poor', 'Perfect'], Size: ['Too small', 'Too wide'], Width: ['Too narrow', 'Too wide'] }


### PR DESCRIPTION
@mayliang021 

Please review these proposed changes to RatingScale.jsx and let me know if this will cause any issues with downstream code

Fixes typo FROM: import {VscTriangleDown} from 'react-icons/Vsc
TO: import {VscTriangleDown} from 'react-icons/vsc

That was resulting in React being unable to properly import react-icons package